### PR TITLE
Remove gpsd and sense-hat node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "@types/node": "^20.5.1",
     "fastify": "^4.25.2",
     "nconf": "=0.12.0",
-    "node-gpsd-client": "^1.4.1",
-    "sense-hat-led": "^1.2.0",
     "strip-ansi": "^6.0.1",
     "uuid": "^9.0.1"
   },


### PR DESCRIPTION
Removing both the gpsd and sense-hat node modules as they're a remnant from previous rPi-based demoware work.